### PR TITLE
Fixing Greg's title and link

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -54,7 +54,7 @@
                                     <!-- <h4 class="subheading">Our Humble Beginnings</h4> -->
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted"><p class="text-muted">We have four great keynote speakers: <a href="http://valerieaurora.org/">Valerie Aurora</a>, a software engineer turned diversity and inclusion consultant, <a href="https://twitter.com/aneldavdw">Anelda van der Walt</a>, our 2017 Community Service Award winner, <a href="https://twitter.com/gvwilson">Dr Greg Wilson</a>, founder of <a href="https://software-carpentry.org/">Software Carpentry</a>, and <a href="http://www.ucd.ie/conway/research/researchers/conwayfellowsa-z/professordeshiggins/">Professor Desmond Higgins</a>, a bioinformatician who developed the Clustal package for multiple sequence alignment. </p>
+                                    <p class="text-muted"><p class="text-muted">We have four great keynote speakers: <a href="http://valerieaurora.org/">Valerie Aurora</a>, a software engineer turned diversity and inclusion consultant, <a href="https://twitter.com/aneldavdw">Anelda van der Walt</a>, our 2017 Community Service Award winner, <a href="http://third-bit.com/">Greg Wilson</a>, founder of <a href="https://software-carpentry.org/">Software Carpentry</a>, and <a href="http://www.ucd.ie/conway/research/researchers/conwayfellowsa-z/professordeshiggins/">Professor Desmond Higgins</a>, a bioinformatician who developed the Clustal package for multiple sequence alignment. </p>
                                 </div>
                             </div>
                         </li>

--- a/_includes/comp.html
+++ b/_includes/comp.html
@@ -85,7 +85,7 @@
     </div>
     <div class="col-lg-10 col-md-8 col-sm-12">
       <p>
-        <a href="https://twitter.com/gvwilson">Dr Greg Wilson</a> has worked for 30 years in both industry and academia, and is the author or editor of
+        <a href="http://third-bit.com/">Greg Wilson</a> has worked for 30 years in both industry and academia, and is the author or editor of
           several books on computing and two for children.
           He co-founded <a href="https://software-carpentry.org/">Software Carpentry</a>, and is now Head of Instructor Training for <a href="https://www.datacamp.com/home">DataCamp</a>.
       </p>

--- a/_includes/program.html
+++ b/_includes/program.html
@@ -82,7 +82,7 @@
               <tr>
                 <td>Wednesday</td>
                 <td>1:30-2:35 pm</td>
-                <td><b>Keynote</b>: Dr Greg Wilson<br>
+                <td><b>Keynote</b>: Greg Wilson<br>
                  <em>Late Night Thoughts on Listening to Ike Quebec</em><br \>
                   <small>Includes question time</small></td>
 


### PR DESCRIPTION
1. Lots of other speakers and facilitators are "Dr" too, so it feels weird to have it only in front of my name.
2. I'd prefer to link to my website (http://third-bit.com) rather than to my Twitter handle, since I'm ramping down Twitter activity.