### PR TITLE
Changing order of menu items to correspond to order of items in page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+.jekyll-metadata
 
 # Windows image file caches
 Thumbs.db

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,34 +22,30 @@
                     <li class="hidden">
                         <a href="#page-top"></a>
                     </li>
-                                    
                     <li>
                         <a class="page-scroll" href="#about">About</a>
                     </li>
-						<li>
+		    <li>
                         <a class="page-scroll" href="#comp">Speakers</a>
                     </li>
-						                    <li>
-                        <a class="page-scroll" href="#prog">Program</a>
-                    </li>	
-						                    <li>
+		    <li>
                         <a class="page-scroll" href="#donor">Sponsors</a>
                     </li>
-			
-			                    <li>
+		    <li>
                         <a class="page-scroll" href="#portfolio">Sponsorship</a>
                     </li>
-	
-			                    <li>
+		    <li>
+                        <a class="page-scroll" href="#prog">Program</a>
+                    </li>	
+		    <li>
                         <a class="page-scroll" href="#rego">Register</a>
                     </li>
-						                    <li>
+		    <li>
                         <a class="page-scroll" href="#accom">Accomm</a>
                     </li>
-			                    <li>
+		    <li>
                         <a class="page-scroll" href="#contact">Contact</a>
                     </li>
-
                 </ul>
             </div>
             <!-- /.navbar-collapse -->


### PR DESCRIPTION
1. Moved link to program in `header.html` so that menu items are in the same order as page elements.
2. Added `.jekyll-metadata` to `.gitignore` so that shrapnel from local builds doesn't appear in Git.